### PR TITLE
Option including delimiters in precidence regexes

### DIFF
--- a/IncludeToolbox/Commands/FormatIncludes.cs
+++ b/IncludeToolbox/Commands/FormatIncludes.cs
@@ -79,7 +79,7 @@ namespace IncludeToolbox.Commands
                     line.UpdateTextWithIncludeContent();
 
                 // Sorting. Ignores non-include lines.
-                IncludeFormatter.IncludeFormatter.SortIncludes(lines, settings.SortByType, settings.PrecedenceRegexes, document.Name);
+                IncludeFormatter.IncludeFormatter.SortIncludes(lines, settings.SortByType, settings.RegexIncludeDelimiter, settings.PrecedenceRegexes, document.Name);
 
                 // Overwrite.
                 string replaceText = string.Join(Environment.NewLine, lines.Select(x => x.Text));

--- a/IncludeToolbox/IncludeFormatter/IncludeFormatter.cs
+++ b/IncludeToolbox/IncludeFormatter/IncludeFormatter.cs
@@ -86,10 +86,10 @@ namespace IncludeToolbox.IncludeFormatter
             }
         }
 
-        public static void SortIncludes(IncludeLineInfo[] lines, FormatterOptionsPage.TypeSorting typeSorting, string[] precedenceRegexes, string documentName)
+        public static void SortIncludes(IncludeLineInfo[] lines, FormatterOptionsPage.TypeSorting typeSorting, bool regexIncludeDelimiter, string[] precedenceRegexes, string documentName)
         {
             var comparer = new IncludeComparer(precedenceRegexes, documentName);
-            var sortedIncludes = lines.Where(x => x.LineType != IncludeLineInfo.Type.NoInclude).OrderBy(x => x.IncludeContent, comparer);
+            var sortedIncludes = lines.Where(x => x.LineType != IncludeLineInfo.Type.NoInclude).OrderBy(x => x.IncludeContentForRegex(regexIncludeDelimiter), comparer);
 
             if (typeSorting == FormatterOptionsPage.TypeSorting.AngleBracketsFirst)
                 sortedIncludes = sortedIncludes.OrderBy(x => x.LineType == IncludeLineInfo.Type.AngleBrackets ? 0 : 1);

--- a/IncludeToolbox/IncludeFormatter/IncludeLineInfo.cs
+++ b/IncludeToolbox/IncludeFormatter/IncludeLineInfo.cs
@@ -146,6 +146,21 @@ namespace IncludeToolbox.IncludeFormatter
             Delimiter1 = Delimiter0 + includeContent.Length + 1;
         }
 
+        public string IncludeContentForRegex(bool regexIncludeDelimiter)
+        {
+            if (!regexIncludeDelimiter || lineType == Type.NoInclude)
+                return includeContent;
+
+            char[] delimiters = { '"', '"' };
+            if (lineType == Type.AngleBrackets)
+            {
+                delimiters[0] = '<';
+                delimiters[1] = '>';
+            }
+
+            return String.Format("{0}{1}{2}", delimiters[0], includeContent, delimiters[1]);
+        }
+
         public string Text
         {
             get { return text; }

--- a/IncludeToolbox/Options/FormatterOptionsPage.cs
+++ b/IncludeToolbox/Options/FormatterOptionsPage.cs
@@ -75,13 +75,18 @@ namespace IncludeToolbox
         #region Sorting
 
         [Category("Sorting")]
+        [DisplayName("Include delimiters in precedence regexes")]
+        [Description("If true, precedence regexes will consider delimiters (angle brackets or quotes.)")]
+        public bool RegexIncludeDelimiter { get; set; } = false;
+
+        [Category("Sorting")]
         [DisplayName("Precedence Regexes")]
         [Description("Earlier match means higher sorting priority.\n\" " + IncludeComparer.CurrentFileNameKey + "\" will be replaced with the current file name without extension.")]
         public string[] PrecedenceRegexes {
             get { return precedenceRegexes; }
             set { precedenceRegexes = value.Where(x => x.Length > 0).ToArray(); } // Remove empty lines.
         }
-        private string[] precedenceRegexes = new string[] { "$(currentFilename)\\.(?i)(h|hpp|hxx|inl|c|cpp|cxx)(?-i)$" };
+        private string[] precedenceRegexes = new string[] { "(?i)$(currentFilename)\\.(h|hpp|hxx|inl|c|cpp|cxx)(?-i)" };
 
         public enum TypeSorting
         {
@@ -121,6 +126,7 @@ namespace IncludeToolbox
             settingsStore.SetInt32(collectionName, nameof(SlashFormatting), (int)SlashFormatting);
             settingsStore.SetBoolean(collectionName, nameof(RemoveEmptyLines), RemoveEmptyLines);
 
+            settingsStore.SetBoolean(collectionName, nameof(RegexIncludeDelimiter), RegexIncludeDelimiter);
             var value = string.Join("\n", PrecedenceRegexes);
             settingsStore.SetString(collectionName, nameof(PrecedenceRegexes), value);
             settingsStore.SetInt32(collectionName, nameof(SortByType), (int)SortByType);
@@ -142,6 +148,8 @@ namespace IncludeToolbox
             if (settingsStore.PropertyExists(collectionName, nameof(RemoveEmptyLines)))
                 RemoveEmptyLines = settingsStore.GetBoolean(collectionName, nameof(RemoveEmptyLines));
 
+            if (settingsStore.PropertyExists(collectionName, nameof(RegexIncludeDelimiter)))
+                RegexIncludeDelimiter = settingsStore.GetBoolean(collectionName, nameof(RegexIncludeDelimiter));
             if (settingsStore.PropertyExists(collectionName, nameof(PrecedenceRegexes)))
             {
                 var value = settingsStore.GetString(collectionName, nameof(PrecedenceRegexes));

--- a/IncludeToolbox/Package/source.extension.vsixmanifest
+++ b/IncludeToolbox/Package/source.extension.vsixmanifest
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="IncludeToolbox.Andreas Reich.075c2e2b-7b71-45ba-b2e6-c1dadc81cfac" Version="1.1" Language="en-US" Publisher="Andreas Reich" />
-    <DisplayName>IncludeToolbox</DisplayName>
-    <Description xml:space="preserve">Various tools for managing C/C++ #includes: Formatting, sorting, exploring, pruning.</Description>
-    <License>license.txt</License>
-    <Icon>Resources\IncludeFormatterPackage.png</Icon>
-    <Tags>Include, Include What You Use, IWYU, Include Formatting, Include Sorting, #include, Include Removal</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0)" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0]" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="IncludeToolbox.Andreas Reich.075c2e2b-7b71-45ba-b2e6-c1dadc81cfac" Version="1.2" Language="en-US" Publisher="Andreas Reich" />
+        <DisplayName>IncludeToolbox</DisplayName>
+        <Description xml:space="preserve">Various tools for managing C/C++ #includes: Formatting, sorting, exploring, pruning.</Description>
+        <License>license.txt</License>
+        <Icon>Resources\IncludeFormatterPackage.png</Icon>
+        <Tags>Include, Include What You Use, IWYU, Include Formatting, Include Sorting, #include, Include Removal</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0)" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+        <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0]" />
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
 </PackageManifest>


### PR DESCRIPTION
The option defaults to false, but the use-case is for a coding standard
with a preferred include order like:

```
- stdafx.h (for precompiled header – must be first).
- myfilename.h (corresponding header for .cpp).
- C system files.
- C++ system files.
- Other libraries' .h files.
- Your project's .h files.
```

In the above case, C system files can be detected as includes using angled
brackets and containing a dot (e.g. '<[^.]*.'), while C++ system files
can be detected as includes using angled brackets but contining no dot
(e.g.  '<'). So, to make this work, the delimiters must be included for
comparison in the regexes.
