### PR TITLE
Option to add newline between regex groups

### DIFF
--- a/IncludeToolbox/Commands/FormatIncludes.cs
+++ b/IncludeToolbox/Commands/FormatIncludes.cs
@@ -79,7 +79,7 @@ namespace IncludeToolbox.Commands
                     line.UpdateTextWithIncludeContent();
 
                 // Sorting. Ignores non-include lines.
-                IncludeFormatter.IncludeFormatter.SortIncludes(lines, settings.SortByType, settings.RegexIncludeDelimiter, settings.PrecedenceRegexes, document.Name);
+                IncludeFormatter.IncludeFormatter.SortIncludes(lines, settings, document.Name);
 
                 // Overwrite.
                 string replaceText = string.Join(Environment.NewLine, lines.Select(x => x.Text));

--- a/IncludeToolbox/IncludeFormatter/IncludeComparer.cs
+++ b/IncludeToolbox/IncludeFormatter/IncludeComparer.cs
@@ -12,14 +12,14 @@ namespace IncludeToolbox.IncludeFormatter
         {
             string currentFilename = documentName.Substring(0, documentName.LastIndexOf('.'));
 
-            this.precedenceRegexes = new string[precedenceRegexes.Length];
-            for (int i = 0; i < this.precedenceRegexes.Length; ++i)
+            PrecedenceRegexes = new string[precedenceRegexes.Length];
+            for (int i = 0; i < PrecedenceRegexes.Length; ++i)
             {
-                this.precedenceRegexes[i] = precedenceRegexes[i].Replace(CurrentFileNameKey, currentFilename);
+                PrecedenceRegexes[i] = precedenceRegexes[i].Replace(CurrentFileNameKey, currentFilename);
             }
         }
 
-        private readonly string[] precedenceRegexes;
+        public string[] PrecedenceRegexes { get; set; }
 
         public int Compare(string lineA, string lineB)
         {
@@ -35,15 +35,15 @@ namespace IncludeToolbox.IncludeFormatter
             }
 
             int precedenceA = 0;
-            for (; precedenceA < precedenceRegexes.Length; ++precedenceA)
+            for (; precedenceA < PrecedenceRegexes.Length; ++precedenceA)
             {
-                if (Regex.Match(lineA, precedenceRegexes[precedenceA]).Success)
+                if (Regex.Match(lineA, PrecedenceRegexes[precedenceA]).Success)
                     break;
             }
             int precedenceB = 0;
-            for (; precedenceB < precedenceRegexes.Length; ++precedenceB)
+            for (; precedenceB < PrecedenceRegexes.Length; ++precedenceB)
             {
-                if (Regex.Match(lineB, precedenceRegexes[precedenceB]).Success)
+                if (Regex.Match(lineB, PrecedenceRegexes[precedenceB]).Success)
                     break;
             }
 

--- a/IncludeToolbox/IncludeFormatter/IncludeFormatter.cs
+++ b/IncludeToolbox/IncludeFormatter/IncludeFormatter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace IncludeToolbox.IncludeFormatter
 {
@@ -86,25 +87,84 @@ namespace IncludeToolbox.IncludeFormatter
             }
         }
 
-        public static void SortIncludes(IncludeLineInfo[] lines, FormatterOptionsPage.TypeSorting typeSorting, bool regexIncludeDelimiter, string[] precedenceRegexes, string documentName)
+        public static void SortIncludes(IncludeLineInfo[] lines, FormatterOptionsPage settings, string documentName)
         {
-            var comparer = new IncludeComparer(precedenceRegexes, documentName);
-            var sortedIncludes = lines.Where(x => x.LineType != IncludeLineInfo.Type.NoInclude).OrderBy(x => x.IncludeContentForRegex(regexIncludeDelimiter), comparer);
+            FormatterOptionsPage.TypeSorting typeSorting = settings.SortByType;
+            bool regexIncludeDelimiter = settings.RegexIncludeDelimiter;
+            bool blankAfterRegexGroupMatch = settings.BlankAfterRegexGroupMatch;
+            bool removeEmptyLines = settings.RemoveEmptyLines;
 
-            if (typeSorting == FormatterOptionsPage.TypeSorting.AngleBracketsFirst)
-                sortedIncludes = sortedIncludes.OrderBy(x => x.LineType == IncludeLineInfo.Type.AngleBrackets ? 0 : 1);
-            else if (typeSorting == FormatterOptionsPage.TypeSorting.QuotedFirst)
-                sortedIncludes = sortedIncludes.OrderBy(x => x.LineType == IncludeLineInfo.Type.Quotes ? 0 : 1);
+            var comparer = new IncludeComparer(settings.PrecedenceRegexes, documentName);
+            string[] precedenceRegexes = comparer.PrecedenceRegexes;
 
-            int incIdx = 0;
-            var sortedIncludesArray = sortedIncludes.ToArray();
-            for (int allIdx = 0; allIdx < lines.Length && incIdx < sortedIncludesArray.Length; ++allIdx)
+            var sortedIncludes = lines.Where(x => x.LineType != IncludeLineInfo.Type.NoInclude).OrderBy(x => x.IncludeContentForRegex(regexIncludeDelimiter), comparer).ToArray();
+
+            var mapSortedIndexToRealIndex = new Dictionary<int, int>();
             {
-                if (lines[allIdx].LineType != IncludeLineInfo.Type.NoInclude)
+                int sortedIdx = 0;
+                for (int realIdx = 0; realIdx < lines.Length && sortedIdx < sortedIncludes.Length; ++realIdx)
                 {
-                    lines[allIdx] = sortedIncludesArray[incIdx];
-                    ++incIdx;
+                    if (lines[realIdx].LineType != IncludeLineInfo.Type.NoInclude)
+                    {
+                        mapSortedIndexToRealIndex.Add(sortedIdx, realIdx);
+                        ++sortedIdx;
+                    }
                 }
+            }
+
+            // Optionally insert newlines between regex match groups
+            if (blankAfterRegexGroupMatch && precedenceRegexes.Length > 0 && sortedIncludes.Length > 1)
+            {
+                // Zip the sorted includes up with their index
+                var sortedIncludesAndIndex = Enumerable.Range(0, sortedIncludes.Length).Zip(sortedIncludes, (x, y) => new { index = x, sortedInclude = y });
+
+                // Group the sorted includes by the index of the precedence regex they match, -1 for
+                // NoInclude lines, or precedenceRegexes.Length for no match.
+                var includeGroups = sortedIncludesAndIndex.GroupBy(x =>
+                {
+                    if (x.sortedInclude.LineType == IncludeLineInfo.Type.NoInclude)
+                        return -1;
+
+                    var sortedIncludeContent = x.sortedInclude.IncludeContentForRegex(regexIncludeDelimiter);
+                    for (int precedence = 0; precedence < precedenceRegexes.Count(); ++precedence)
+                    {
+                        if (Regex.Match(sortedIncludeContent, precedenceRegexes[precedence]).Success)
+                        {
+                            return precedence;
+                        }
+                    }
+
+                    return precedenceRegexes.Length;
+                }, x => x);
+
+                // Go through all but the first group and prepend a newline to each group's first
+                // include
+                foreach (var grouping in includeGroups.Where(x => x.Key >= 0).Skip(1))
+                {
+                    var startGroup = grouping.First();
+
+                    if (!removeEmptyLines)
+                    {
+                        // If we don't want to remove empty lines and the line before this group is
+                        // already empty, do nothing
+                        int realIdx = mapSortedIndexToRealIndex[startGroup.index];
+                        if (realIdx > 0 && lines[realIdx - 1].LineType == IncludeLineInfo.Type.NoInclude)
+                            continue;
+                    }
+
+                    startGroup.sortedInclude.Text = String.Format("{0}{1}", Environment.NewLine, startGroup.sortedInclude.Text);
+                }
+            }
+            
+            if (typeSorting == FormatterOptionsPage.TypeSorting.AngleBracketsFirst)
+                sortedIncludes = sortedIncludes.OrderBy(x => x.LineType == IncludeLineInfo.Type.AngleBrackets ? 0 : 1).ToArray();
+            else if (typeSorting == FormatterOptionsPage.TypeSorting.QuotedFirst)
+                sortedIncludes = sortedIncludes.OrderBy(x => x.LineType == IncludeLineInfo.Type.Quotes ? 0 : 1).ToArray();
+
+            for (int sortedIncludeIdx = 0; sortedIncludeIdx < sortedIncludes.Count(); ++sortedIncludeIdx)
+            {
+                int realIdx = mapSortedIndexToRealIndex[sortedIncludeIdx];
+                lines[realIdx] = sortedIncludes[sortedIncludeIdx];
             }
         }
     }

--- a/IncludeToolbox/IncludeFormatter/IncludeLineInfo.cs
+++ b/IncludeToolbox/IncludeFormatter/IncludeLineInfo.cs
@@ -164,8 +164,9 @@ namespace IncludeToolbox.IncludeFormatter
         public string Text
         {
             get { return text; }
+            set { text = value; }
         }
-        private string text;
+        private string text = "";
 
         public string IncludeContent
         {

--- a/IncludeToolbox/IncludeToolbox.csproj
+++ b/IncludeToolbox/IncludeToolbox.csproj
@@ -8,6 +8,9 @@
     </NuGetPackageImportStamp>
     <UseCodebase>true</UseCodebase>
     <TargetFrameworkProfile />
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/IncludeToolbox/Options/FormatterOptionsPage.cs
+++ b/IncludeToolbox/Options/FormatterOptionsPage.cs
@@ -80,6 +80,11 @@ namespace IncludeToolbox
         public bool RegexIncludeDelimiter { get; set; } = false;
 
         [Category("Sorting")]
+        [DisplayName("Insert blank line between precedence regex match groups")]
+        [Description("If true, a blank line will be inserted after each group matching one of the precedence regexes.")]
+        public bool BlankAfterRegexGroupMatch { get; set; } = false;
+
+        [Category("Sorting")]
         [DisplayName("Precedence Regexes")]
         [Description("Earlier match means higher sorting priority.\n\" " + IncludeComparer.CurrentFileNameKey + "\" will be replaced with the current file name without extension.")]
         public string[] PrecedenceRegexes {
@@ -127,6 +132,7 @@ namespace IncludeToolbox
             settingsStore.SetBoolean(collectionName, nameof(RemoveEmptyLines), RemoveEmptyLines);
 
             settingsStore.SetBoolean(collectionName, nameof(RegexIncludeDelimiter), RegexIncludeDelimiter);
+            settingsStore.SetBoolean(collectionName, nameof(BlankAfterRegexGroupMatch), BlankAfterRegexGroupMatch);
             var value = string.Join("\n", PrecedenceRegexes);
             settingsStore.SetString(collectionName, nameof(PrecedenceRegexes), value);
             settingsStore.SetInt32(collectionName, nameof(SortByType), (int)SortByType);
@@ -150,6 +156,8 @@ namespace IncludeToolbox
 
             if (settingsStore.PropertyExists(collectionName, nameof(RegexIncludeDelimiter)))
                 RegexIncludeDelimiter = settingsStore.GetBoolean(collectionName, nameof(RegexIncludeDelimiter));
+            if (settingsStore.PropertyExists(collectionName, nameof(BlankAfterRegexGroupMatch)))
+                BlankAfterRegexGroupMatch = settingsStore.GetBoolean(collectionName, nameof(BlankAfterRegexGroupMatch));
             if (settingsStore.PropertyExists(collectionName, nameof(PrecedenceRegexes)))
             {
                 var value = settingsStore.GetString(collectionName, nameof(PrecedenceRegexes));

--- a/IncludeToolbox/Package/source.extension.vsixmanifest
+++ b/IncludeToolbox/Package/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="IncludeToolbox.Andreas Reich.075c2e2b-7b71-45ba-b2e6-c1dadc81cfac" Version="1.2" Language="en-US" Publisher="Andreas Reich" />
+        <Identity Id="IncludeToolbox.Andreas Reich.075c2e2b-7b71-45ba-b2e6-c1dadc81cfac" Version="1.3" Language="en-US" Publisher="Andreas Reich" />
         <DisplayName>IncludeToolbox</DisplayName>
         <Description xml:space="preserve">Various tools for managing C/C++ #includes: Formatting, sorting, exploring, pruning.</Description>
         <License>license.txt</License>


### PR DESCRIPTION
The option defaults to false. If true, when sorting includes with regex
precedence groups, a blank line will be added after each matching group of
include statements.
