### PR TITLE
Allow unlimited clang errors

### DIFF
--- a/IncludeToolbox.vsix
+++ b/IncludeToolbox.vsix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:47652665d83f488f990a6362a85a5967a51f78d5231dbe3a5ac8f0a95c19cab6
-size 4736779
+oid sha256:807effcd78b1d453ab92eb85fef9fd71ec6d3a24e13041bd6ec90522a77fea5a
+size 4736679

--- a/IncludeToolbox/Commands/IncludeWhatYouUse.cs
+++ b/IncludeToolbox/Commands/IncludeWhatYouUse.cs
@@ -240,7 +240,7 @@ namespace IncludeToolbox.Commands
                 process.StartInfo.Arguments += " -DM_X64 -DM_AMD64 ";// TODO!!!
 
                 // Clang options
-                process.StartInfo.Arguments += "-w -x c++ -std=c++14 -fcxx-exceptions -fexceptions -fms-compatibility -fms-extensions -fmsc-version=1900 -Wno-invalid-token-paste "; // todo fmsc-version!
+                process.StartInfo.Arguments += "-w -x c++ -std=c++14 -fcxx-exceptions -fexceptions -fms-compatibility -fms-extensions -fmsc-version=1900 -ferror-limit=0 -Wno-invalid-token-paste "; // todo fmsc-version!
                 // icwyu options
                 {
                     process.StartInfo.Arguments += "-Xiwyu --verbose=" + settings.LogVerbosity + " ";

--- a/IncludeToolbox/Package/source.extension.vsixmanifest
+++ b/IncludeToolbox/Package/source.extension.vsixmanifest
@@ -1,21 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="IncludeToolbox.Andreas Reich.075c2e2b-7b71-45ba-b2e6-c1dadc81cfac" Version="1.3" Language="en-US" Publisher="Andreas Reich" />
-        <DisplayName>IncludeToolbox</DisplayName>
-        <Description xml:space="preserve">Various tools for managing C/C++ #includes: Formatting, sorting, exploring, pruning.</Description>
-        <License>license.txt</License>
-        <Icon>Resources\IncludeFormatterPackage.png</Icon>
-        <Tags>Include, Include What You Use, IWYU, Include Formatting, Include Sorting, #include, Include Removal</Tags>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0)" />
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-        <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0]" />
-    </Dependencies>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    </Assets>
+  <Metadata>
+    <Identity Id="IncludeToolbox.Andreas Reich.075c2e2b-7b71-45ba-b2e6-c1dadc81cfac" Version="1.3.1" Language="en-US" Publisher="Andreas Reich" />
+    <DisplayName>IncludeToolbox</DisplayName>
+    <Description xml:space="preserve">Various tools for managing C/C++ #includes: Formatting, sorting, exploring, pruning.</Description>
+    <License>license.txt</License>
+    <Icon>Resources\IncludeFormatterPackage.png</Icon>
+    <PreviewImage>Resources\IncludeFormatterPackage.png</PreviewImage>
+    <Tags>Include, Include What You Use, IWYU, Include Formatting, Include Sorting, #include, Include Removal</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0)" />
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0]" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+  </Assets>
 </PackageManifest>


### PR DESCRIPTION
By default, clang will stop after 20 errors. Since most of the people
using VC++ probably don't build with clang, I would expect a lot more
errors.

This allows clang to keep going by telling it to allow an unlimited number
of errors.

I found that IWYU would miss things because it stopped too soon and with
this setting enabled it seems to give a better end result.
