### PR TITLE
Add option (on by default) to remove duplicates

### DIFF
--- a/IncludeToolbox.vsix
+++ b/IncludeToolbox.vsix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96da2600a661f022024c446771873504e6aec1d77a25c0f0268adbe1e7dcb784
-size 127921
+oid sha256:77be8c5da4736b2179aefe8d63416b22e9669705abb3b737253894c7e5ce1d9d
+size 127968

--- a/IncludeToolbox/Formatter/IncludeFormatter.cs
+++ b/IncludeToolbox/Formatter/IncludeFormatter.cs
@@ -134,7 +134,15 @@ namespace IncludeToolbox.Formatter
             // order when rearranged by regex precedence groups.
             var includeLines = includeBatch
                 .Where(x => x.ContainsActiveInclude)
-                .OrderBy(x => x.IncludeContent);
+                .OrderBy(x => x.IncludeContent)
+                .ToList();
+
+            if (settings.RemoveDuplicates)
+            {
+                HashSet<string> uniqueIncludes = new HashSet<string>();
+                includeLines.RemoveAll(x => !x.ShouldBePreserved &&
+                                            !uniqueIncludes.Add(x.GetIncludeContentWithDelimiters()));
+            }
 
             // Group the includes by the index of the precedence regex they match, or
             // precedenceRegexes.Length for no match, and sort the groups by index.
@@ -176,7 +184,7 @@ namespace IncludeToolbox.Formatter
 
                 foreach (var sortedLine in sortedIncludes)
                 {
-                    // Advance until there is a include line to replace. There *must* be one left if sortedIncludes is not empty.
+                    // Advance until there is an include line to replace. There *must* be one left if sortedIncludes is not empty.
                     while (!originalLineEnumerator.Current.ContainsActiveInclude)
                     {
                         outSortedList.Add(originalLineEnumerator.Current);
@@ -197,6 +205,13 @@ namespace IncludeToolbox.Formatter
                     }
                     outSortedList.Add(sortedLine);
                     firstLine = false;
+                }
+
+                while (hasElements)
+                {
+                    if (!originalLineEnumerator.Current.ContainsActiveInclude)
+                        outSortedList.Add(originalLineEnumerator.Current);
+                    hasElements = originalLineEnumerator.MoveNext();
                 }
             }
 

--- a/IncludeToolbox/Formatter/IncludeLineInfo.cs
+++ b/IncludeToolbox/Formatter/IncludeLineInfo.cs
@@ -78,7 +78,7 @@ namespace IncludeToolbox.Formatter
                         ++openMultiLineComments;
                         commentedSectionStart = multiLineCommentStart;
                     }
-                    
+
                     int multiLineCommentEnd = lineText.IndexOf("*/");
                     if (multiLineCommentEnd > -1)
                     {
@@ -109,7 +109,7 @@ namespace IncludeToolbox.Formatter
                 int includeOccurence = lineText.IndexOf("#include");
 
                 // Not a valid include.
-                if (includeOccurence == -1 ||        // Include not found 
+                if (includeOccurence == -1 ||        // Include not found
                     isCommented(includeOccurence) || // Include commented out
                     openIfdefs > 0)                // Inside an #ifdef block
                 {
@@ -204,11 +204,11 @@ namespace IncludeToolbox.Formatter
         }
 
         /// <summary>
-        /// Wheather the line contains a preprocessor directive.
+        /// Whether the line contains a preprocessor directive.
         /// Does not take into account surrounding block comments.
         /// </summary>
         public bool ContainsPreProcessorDirective
-        {   
+        {
             get
             {
                 // In theory the '#' of a preprocessor directive MUST come first, but just like MSVC we relax the rules a bit here.
@@ -270,7 +270,7 @@ namespace IncludeToolbox.Formatter
 
 
         /// <summary>
-        /// Changes in the include content will NOT be reflected immediately in the raw line text. 
+        /// Changes in the include content will NOT be reflected immediately in the raw line text.
         /// </summary>
         /// <see cref="UpdateRawLineWithIncludeContentChanges"/>
         public string IncludeContent

--- a/IncludeToolbox/Options/FormatterOptionsPage.cs
+++ b/IncludeToolbox/Options/FormatterOptionsPage.cs
@@ -100,6 +100,11 @@ namespace IncludeToolbox
         [Description("Optionally put either includes with angle brackets <...> or quotes \"...\" first.")]
         public TypeSorting SortByType { get; set; } = TypeSorting.QuotedFirst;
 
+        [Category("Sorting")]
+        [DisplayName("Remove duplicates")]
+        [Description("If true, duplicate includes will be removed.")]
+        public bool RemoveDuplicates { get; set; } = true;
+
         #endregion
 
         public override void SaveSettingsToStorage()
@@ -121,6 +126,7 @@ namespace IncludeToolbox
             var value = string.Join("\n", PrecedenceRegexes);
             settingsStore.SetString(collectionName, nameof(PrecedenceRegexes), value);
             settingsStore.SetInt32(collectionName, nameof(SortByType), (int)SortByType);
+            settingsStore.SetBoolean(collectionName, nameof(RemoveDuplicates), RemoveDuplicates);
         }
 
         public override void LoadSettingsFromStorage()
@@ -150,6 +156,8 @@ namespace IncludeToolbox
             }
             if (settingsStore.PropertyExists(collectionName, nameof(SortByType)))
                 SortByType = (TypeSorting) settingsStore.GetInt32(collectionName, nameof(SortByType));
+            if (settingsStore.PropertyExists(collectionName, nameof(RemoveDuplicates)))
+                RemoveDuplicates = settingsStore.GetBoolean(collectionName, nameof(RemoveDuplicates));
         }
     }
 }

--- a/IncludeToolbox/Package/source.extension.vsixmanifest
+++ b/IncludeToolbox/Package/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="IncludeToolbox.Andreas Reich.075c2e2b-7b71-45ba-b2e6-c1dadc81cfac" Version="2.2.0" Language="en-US" Publisher="Andreas Reich" />
+        <Identity Id="IncludeToolbox.Andreas Reich.075c2e2b-7b71-45ba-b2e6-c1dadc81cfac" Version="2.2.0.1" Language="en-US" Publisher="Andreas Reich" />
         <DisplayName>IncludeToolbox</DisplayName>
         <Description xml:space="preserve">Various tools for managing C/C++ #includes: Formatting, sorting, exploring, pruning.</Description>
         <License>license.txt</License>

--- a/Tests/IncludeFormatingTest.cs
+++ b/Tests/IncludeFormatingTest.cs
@@ -10,20 +10,29 @@ namespace Tests
         private static string sourceCode_NoBlanks =
 @"#include ""a.h""
 #include <b.hpp>
+#include ""a.h""
 #include ""filename.h""
+#include <b.hpp>
 #include <d_firstanyways>
 #include <e_secondanyways>
-#include <c.hpp>";
+#include <e_secondanyways>
+#include <c.hpp>
+#include <d_firstanyways>";
 
         private static string sourceCode_WithBlanks =
 @"#include ""c_third""
 
 #include ""filename.h""
 
+#include ""z_first""
+
+#include <b_second>
 #include <b_second>
 // A comment
-#include ""z_first""";
+#include ""z_first""
 
+#include <b_second>
+#include ""filename.h""";
 
         [TestMethod]
         public void Sorting_BlanksAfterRegexGroup()
@@ -45,8 +54,10 @@ namespace Tests
 #include <b_second>
 
 #include ""c_third""
+
+#include ""z_first""
 // A comment
-#include ""z_first""";
+";
 
 
             var settings = new IncludeToolbox.FormatterOptionsPage();
@@ -85,8 +96,10 @@ namespace Tests
 #include ""filename.h""
 
 #include ""c_third""
+
+#include ""z_first""
 // A comment
-#include ""z_first""";
+";
 
 
             var settings = new IncludeToolbox.FormatterOptionsPage();
@@ -106,14 +119,63 @@ namespace Tests
         }
 
         [TestMethod]
+        public void Sorting_DontRemoveDuplicates()
+        {
+            // With sort by type.
+            string expectedFormatedCode_NoBlanks =
+@"#include ""filename.h""
+
+#include <d_firstanyways>
+#include <d_firstanyways>
+#include <e_secondanyways>
+#include <e_secondanyways>
+
+#include ""a.h""
+#include ""a.h""
+#include <b.hpp>
+#include <b.hpp>
+#include <c.hpp>";
+
+
+            string expectedFormatedCode_WithBlanks =
+@"#include ""filename.h""
+#include ""filename.h""
+
+#include <b_second>
+#include <b_second>
+#include <b_second>
+// A comment
+#include ""c_third""
+#include ""z_first""
+#include ""z_first""";
+
+
+            var settings = new IncludeToolbox.FormatterOptionsPage();
+            settings.SortByType = IncludeToolbox.FormatterOptionsPage.TypeSorting.None;
+            settings.PrecedenceRegexes = new string[]
+            {
+                    IncludeToolbox.RegexUtils.CurrentFileNameKey,
+                    ".+_.+"
+            };
+            settings.BlankAfterRegexGroupMatch = true;
+            settings.RemoveEmptyLines = true;
+            settings.RemoveDuplicates = false;
+
+            string formatedCode = IncludeFormatter.FormatIncludes(sourceCode_NoBlanks, "filename.cpp", new string[] { }, settings);
+            Assert.AreEqual(expectedFormatedCode_NoBlanks, formatedCode);
+            formatedCode = IncludeFormatter.FormatIncludes(sourceCode_WithBlanks, "filename.cpp", new string[] { }, settings);
+            Assert.AreEqual(expectedFormatedCode_WithBlanks, formatedCode);
+        }
+
+        [TestMethod]
         public void RemoveEmptyLines()
         {
             string expectedFormatedCode_WithBlanks =
 @"#include ""filename.h""
 #include <b_second>
 #include ""c_third""
-// A comment
-#include ""z_first""";
+#include ""z_first""
+// A comment";
 
             var settings = new IncludeToolbox.FormatterOptionsPage();
             settings.SortByType = IncludeToolbox.FormatterOptionsPage.TypeSorting.None;
@@ -148,6 +210,7 @@ namespace Tests
 @"#pragma once
 // SomeComment
 #include ""z""
+#include <b>
 
 #include ""filename.h""
 
@@ -155,6 +218,8 @@ namespace Tests
 #include <d>
 // A comment
 #include ""a9""
+#include <d>
+#include <c>
 #else
 #include <d>
 
@@ -163,17 +228,21 @@ namespace Tests
 
 #include <a2>
 #endif
+#include <b>
 #include <a1>";
 
             string expectedFormatedCode =
 @"#pragma once
 // SomeComment
+#include <b>
 #include ""filename.h""
 
 #include ""z""
+
 #if test
-#include <d>
+#include <c>
 // A comment
+#include <d>
 #include ""a9""
 #else
 #include <a2>
@@ -183,7 +252,8 @@ namespace Tests
 
 #include <d>
 #endif
-#include <a1>";
+#include <a1>
+#include <b>";
 
             var settings = new IncludeToolbox.FormatterOptionsPage();
             settings.SortByType = IncludeToolbox.FormatterOptionsPage.TypeSorting.AngleBracketsFirst;


### PR DESCRIPTION
While sorting, removes duplicate include directives

Notes:

- Only works within batches
- Should respect $include-toolbox-preserve$
- Case sensitive check against include content + delimiters