### PR TITLE
Add new options for formatting relative include paths

### DIFF
--- a/IncludeToolbox.vsix
+++ b/IncludeToolbox.vsix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:50ac3952952fee7141aabb2a03e9cfd968a164a403c8d86529748c7df89d545f
-size 128269
+oid sha256:0c432712fbe792d75f5dff593f0cdad3f2d72cbcd081a6e5a4b6c13c51a07ef8
+size 128533

--- a/IncludeToolbox/Options/FormatterOptionsPage.cs
+++ b/IncludeToolbox/Options/FormatterOptionsPage.cs
@@ -19,6 +19,7 @@ namespace IncludeToolbox
             Shortest,
             Shortest_AvoidUpSteps,
             Absolute,
+            Absolute_FromParentDirWithFile
         }
         [Category("Path")]
         [DisplayName("Mode")]
@@ -26,9 +27,21 @@ namespace IncludeToolbox
         public PathMode PathFormat { get; set; } = PathMode.Shortest_AvoidUpSteps;
 
         [Category("Path")]
+        [DisplayName("Filename in parent directory for absolute include paths")]
+        [Description("The Absolute_FromParentDirWithFile mode will look for this file in parent directories and make include paths absolute from its location.")]
+        public string FromParentDirWithFile { get; set; } = "build.root";
+
+        public enum IgnoreFileRelativeMode
+        {
+            Never,
+            Always,
+            InSameDirectory,
+            InSameOrSubDirectory
+        }
+        [Category("Path")]
         [DisplayName("Ignore File Relative")]
-        [Description("If true, include directives will not take the path of the file into account.")]
-        public bool IgnoreFileRelative { get; set; } = false;
+        [Description("Whether to ignore include paths relative to the current file.")]
+        public IgnoreFileRelativeMode IgnoreFileRelative { get; set; } = IgnoreFileRelativeMode.Never;
 
         //[Category("Path")]
         //[DisplayName("Ignore Standard Library")]
@@ -115,7 +128,8 @@ namespace IncludeToolbox
                 settingsStore.CreateCollection(collectionName);
 
             settingsStore.SetInt32(collectionName, nameof(PathFormat), (int)PathFormat);
-            settingsStore.SetBoolean(collectionName, nameof(IgnoreFileRelative), IgnoreFileRelative);
+            settingsStore.SetString(collectionName, nameof(FromParentDirWithFile), FromParentDirWithFile);
+            settingsStore.SetInt32(collectionName, nameof(IgnoreFileRelative), (int)IgnoreFileRelative);
 
             settingsStore.SetInt32(collectionName, nameof(DelimiterFormatting), (int)DelimiterFormatting);
             settingsStore.SetInt32(collectionName, nameof(SlashFormatting), (int)SlashFormatting);
@@ -135,8 +149,10 @@ namespace IncludeToolbox
 
             if (settingsStore.PropertyExists(collectionName, nameof(PathFormat)))
                 PathFormat = (PathMode)settingsStore.GetInt32(collectionName, nameof(PathFormat));
+            if (settingsStore.PropertyExists(collectionName, nameof(FromParentDirWithFile)))
+                FromParentDirWithFile = settingsStore.GetString(collectionName, nameof(FromParentDirWithFile));
             if (settingsStore.PropertyExists(collectionName, nameof(IgnoreFileRelative)))
-                IgnoreFileRelative = settingsStore.GetBoolean(collectionName, nameof(IgnoreFileRelative));
+                IgnoreFileRelative = (IgnoreFileRelativeMode)settingsStore.GetInt32(collectionName, nameof(IgnoreFileRelative));
 
             if (settingsStore.PropertyExists(collectionName, nameof(DelimiterFormatting)))
                 DelimiterFormatting = (DelimiterMode) settingsStore.GetInt32(collectionName, nameof(DelimiterFormatting));

--- a/IncludeToolbox/Package/source.extension.vsixmanifest
+++ b/IncludeToolbox/Package/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="IncludeToolbox.Andreas Reich.075c2e2b-7b71-45ba-b2e6-c1dadc81cfac" Version="2.2.1" Language="en-US" Publisher="Andreas Reich" />
+        <Identity Id="IncludeToolbox.Andreas Reich.075c2e2b-7b71-45ba-b2e6-c1dadc81cfac" Version="2.2.90" Language="en-US" Publisher="Andreas Reich" />
         <DisplayName>IncludeToolbox</DisplayName>
         <Description xml:space="preserve">Various tools for managing C/C++ #includes: Formatting, sorting, exploring, pruning.</Description>
         <License>license.txt</License>

--- a/IncludeToolbox/Utils.cs
+++ b/IncludeToolbox/Utils.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
-using Microsoft.VisualStudio.VCProjectEngine;
+//using Microsoft.VisualStudio.VCProjectEngine;
 
 namespace IncludeToolbox
 {
@@ -35,23 +35,61 @@ namespace IncludeToolbox
             return relativePath;
         }
 
-        public static string GetExactPathName(string pathName)
+        // Shamelessly stolen from https://stackoverflow.com/a/5076517/153079
+        private static string GetFileSystemCasing(string path)
         {
-            if (!File.Exists(pathName) && !Directory.Exists(pathName))
-                return pathName;
-
-            var di = new DirectoryInfo(pathName);
-
-            if (di.Parent != null)
+            if (Path.IsPathRooted(path))
             {
-                return Path.Combine(
-                    GetExactPathName(di.Parent.FullName),
-                    di.Parent.GetFileSystemInfos(di.Name)[0].Name);
+                path = path.TrimEnd(Path.DirectorySeparatorChar); // if you type c:\foo\ instead of c:\foo
+                try
+                {
+                    string name = Path.GetFileName(path);
+                    if (name == "")
+                        return path.ToUpper() + Path.DirectorySeparatorChar; // root reached
+
+                    string parent = Path.GetDirectoryName(path);
+
+                    parent = GetFileSystemCasing(parent);
+
+                    DirectoryInfo diParent = new DirectoryInfo(parent);
+                    FileSystemInfo[] fsiChildren = diParent.GetFileSystemInfos(name);
+                    FileSystemInfo fsiChild = fsiChildren.First();
+                    return fsiChild.FullName;
+                }
+                catch (Exception ex)
+                {
+                    Output.Instance.ErrorMsg("Invalid path: '{0}'\nError:\n{1}", path, ex.Message);
+                }
             }
             else
             {
-                return di.Name.ToUpper();
+                Output.Instance.ErrorMsg("Absolute path needed, not relative: '{0}'", path);
             }
+
+            return "";
+        }
+
+        /// <summary>
+        /// Gets the path name as it exists it the file system, normalizing it.
+        /// </summary>
+        /// <param name="pathName">Path name</param>
+        /// <returns>Normalized path name. Directories are returned with trailing separator.</returns>
+        public static string GetExactPathName(string pathName)
+        {
+            if (!File.Exists(pathName) && !Directory.Exists(pathName))
+            {
+                return pathName;
+            }
+
+            string exactPathName = GetFileSystemCasing(Path.GetFullPath(pathName).Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));
+            if (exactPathName == "")
+                return pathName;
+
+            // Add trailing slash for directories
+            exactPathName = exactPathName.TrimEnd(Path.DirectorySeparatorChar);
+            if (File.GetAttributes(exactPathName).HasFlag(FileAttributes.Directory))
+                return exactPathName + Path.DirectorySeparatorChar;
+            return exactPathName;
         }
 
         /// <summary>


### PR DESCRIPTION
**NOTE: REVIEW ONLY PR: I still need to add tests for this**

Setting PathFormat=PathMode.Absolute_FromParentDirWithFile in combination
with setting FromParentDirWithFile to a filename that exists "toward" the
root of your source directory tree allows us to make include paths
relative to the nearest parent folder containing the specified file.

This is something we do with our projects in a global property sheet.
MSBuild has the awesome built-in property function
"GetDirectoryNameOfFileAbove", which lets you use a known file (e.g. we
have an empty "build.root" in the root of our source tree) to do the same
thing as this feature. Using this functionality lets you specify things
like additional include/link dirs in a common way that works everywhere so
you don't have to spam a lot of relative paths in your project settings or
include directives.

In other words, with that set, any file can include any header by
specifying its path relative to the root of our source.

To "correctly" handle system includes and includes that are in the same
directory as the file you're working on (that we want to leave path-less),
IgnoreFileRelative was changed from a boolean setting to an enum, where
Never/Always should be the same as false/true and
InSameDirectory/InSameOrSubDirectory provide some more control over which
directives to skip.

I'm not entirely happy with the IgnoreFileRelative setting, I don't think
it's very clear what it's supposed to do (in fact, I don't think I knew
what it did before working on this), so perhaps this could be improved
somehow in the future.