### PR TITLE
Remove check that prevents adding newlines before the last line

### DIFF
--- a/IncludeToolbox.vsix
+++ b/IncludeToolbox.vsix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77be8c5da4736b2179aefe8d63416b22e9669705abb3b737253894c7e5ce1d9d
-size 127968
+oid sha256:50ac3952952fee7141aabb2a03e9cfd968a164a403c8d86529748c7df89d545f
+size 128269

--- a/IncludeToolbox/Package/source.extension.vsixmanifest
+++ b/IncludeToolbox/Package/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="IncludeToolbox.Andreas Reich.075c2e2b-7b71-45ba-b2e6-c1dadc81cfac" Version="2.2.0.1" Language="en-US" Publisher="Andreas Reich" />
+        <Identity Id="IncludeToolbox.Andreas Reich.075c2e2b-7b71-45ba-b2e6-c1dadc81cfac" Version="2.2.1" Language="en-US" Publisher="Andreas Reich" />
         <DisplayName>IncludeToolbox</DisplayName>
         <Description xml:space="preserve">Various tools for managing C/C++ #includes: Formatting, sorting, exploring, pruning.</Description>
         <License>license.txt</License>

--- a/Tests/IncludeFormatingTest.cs
+++ b/Tests/IncludeFormatingTest.cs
@@ -46,7 +46,11 @@ namespace Tests
 
 #include ""a.h""
 #include <b.hpp>
-#include <c.hpp>";
+#include <c.hpp>
+
+
+
+";
 
             string expectedFormatedCode_WithBlanks =
 @"#include ""filename.h""
@@ -56,7 +60,11 @@ namespace Tests
 #include ""c_third""
 
 #include ""z_first""
+
 // A comment
+
+
+
 ";
 
 
@@ -87,7 +95,11 @@ namespace Tests
 #include <b.hpp>
 #include <c.hpp>
 #include ""filename.h""
-#include ""a.h""";
+#include ""a.h""
+
+
+
+";
 
 
             string expectedFormatedCode_WithBlanks =
@@ -98,7 +110,11 @@ namespace Tests
 #include ""c_third""
 
 #include ""z_first""
+
 // A comment
+
+
+
 ";
 
 
@@ -244,6 +260,7 @@ namespace Tests
 // A comment
 #include <d>
 #include ""a9""
+
 #else
 #include <a2>
 


### PR DESCRIPTION
de88fd1c added a check to prevent adding a newline before the last line in
a batch. Since we're prepending, however, a newline is desirable if the
last line is the only one in its group.

Fixes #48