### PR TITLE
Small formatting fixes

### DIFF
--- a/IncludeToolbox/IncludeWhatYouUse/IWYU.cs
+++ b/IncludeToolbox/IncludeWhatYouUse/IWYU.cs
@@ -319,7 +319,7 @@ namespace IncludeToolbox.IncludeWhatYouUse
                 /// https://github.com/Wumpf/IncludeToolbox/issues/36                
                 // Include-paths and Preprocessor.
                 var includes = string.Join(" ", VSUtils.GetProjectIncludeDirectories(project, false).Select(x => "-I \"" + x.Replace("\\", "\\\\") + "\""));
-                var defines = string.Join(" ", preprocessorDefintions.Split(';').Select(x => "-D" + x));
+                var defines = preprocessorDefintions.Length == 0 ? "" : string.Join(" ", preprocessorDefintions.Split(';').Select(x => "-D" + x));
                 var filename = "\"" + fullFileName.Replace("\\", "\\\\") + "\"";
                 var supportFilePath = Path.GetTempFileName();
                 File.WriteAllText(supportFilePath, includes + " " + defines + " " + filename);

--- a/IncludeToolbox/VSUtils.cs
+++ b/IncludeToolbox/VSUtils.cs
@@ -103,6 +103,7 @@ namespace IncludeToolbox
             {
                 try
                 {
+                    pathStrings[i] = pathStrings[i].Trim();
                     if (!Path.IsPathRooted(pathStrings[i]))
                     {
                         pathStrings[i] = Path.Combine(projectPath, pathStrings[i]);


### PR DESCRIPTION
Hi!

I tried to use IncludeToolbox with some projects I work on this week and ran into a couple small formatting issues, mostly to do with odd setup.

- If the project includes come in on separate lines with whitespace at the beginning, IsPathRooted throws
- If the preprocessorDefintions string is "", an extra "-D" is emitted into the tmp file, causing iwyu to error

Both were easy fixes and so I am sending in a pull request. (And I am now happily using the tool!)